### PR TITLE
Fix integer underflow when m4aSoundInit < length

### DIFF
--- a/src/saptapper/mp2k_driver.cpp
+++ b/src/saptapper/mp2k_driver.cpp
@@ -125,7 +125,7 @@ agbptr_t Mp2kDriver::FindVSyncFn(std::string_view rom, agbptr_t init_fn) {
   //
   // Search backwards from m4aSoundInit function.
   const agbsize_t max_pos = init_fn_pos - align;
-  const agbsize_t min_pos = init_fn_pos - length;
+  const agbsize_t min_pos = init_fn_pos - std::min<agbsize_t>(length, init_fn_pos);
   for (agbsize_t offset = max_pos; offset >= min_pos; offset -= align) {
     if (pattern.Match(rom, offset)) {
       // Momotarou Matsuri, Puyo Pop Fever:


### PR DESCRIPTION
If m4aSoundInit is located before 0x8001800, Saptapper will mistakenly attempt to scan for the m4aSoundVSync function at addresses before 0x8000000. This PR fixes that issue.

Found with 'HIGANBANA' (AGB-AHZJ-JPN).

|Name            |Address / Value |
|----------------|----------------|
|m4aSoundVSync   |0x8000a14       |
|m4aSoundInit    |0x8001070       |
|m4aSoundMain    |0x80010e8       |
|m4aSongNumStart |0x80010f4       |
|song_table      |0x8050bc4       |
|len(song_table) |132             |

minigsf information:

|Name            |Address / Value |
|----------------|----------------|
|minigsf address |0x858c578       |
|minigsf size    |1               |